### PR TITLE
Feat/export-model

### DIFF
--- a/lib/groq.dart
+++ b/lib/groq.dart
@@ -29,4 +29,4 @@ export 'src/error.dart'
 
 export 'src/init.dart' show Groq;
 
-export 'src/model.dart' show GroqResponse;
+export 'src/model.dart' show GroqResponse, GroqModel;


### PR DESCRIPTION
Fix for #4 

Hi! I just include export `GroqModel` to use in the factory of the `Groq` model.

```dart
final groq = Groq(model: GroqModel.mixtral, apiKey: 'apiKey');
```

Thanks for your time creating this package!