### PR TITLE
Groq/Model configuration and added response format

### DIFF
--- a/lib/groq.dart
+++ b/lib/groq.dart
@@ -15,6 +15,7 @@
 /// }
 library;
 
+export 'src/api.dart' show GroqConfiguration;
 export 'src/error.dart'
     show
         GroqException,
@@ -26,7 +27,5 @@ export 'src/error.dart'
         RateLimitError,
         InternalServerError,
         APIConnectionError;
-
 export 'src/init.dart' show Groq;
-
 export 'src/model.dart' show GroqResponse, GroqModel;

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -15,22 +15,13 @@ final class ApiHeaderValues {
 }
 
 // Groq API Configuration model
-final class Configuration {
+final class GroqConfiguration {
   /// The model which will generate the completion.
   /// Some models are suitable for natural language
   /// tasks, others specialize in code.
   final GroqModel model;
 
-  String get modelName {
-    switch (model) {
-      case GroqModel.meta:
-        return 'llama2-70b-4096';
-      case GroqModel.mixtral:
-        return 'mixtral-8x7b-32768';
-      case GroqModel.gemma:
-        return 'gemma-7b-it';
-    }
-  }
+  String get modelName => model.name;
 
   /// Controls randomness: lowering results in less
   /// random completions. As the temperature approaches
@@ -59,7 +50,7 @@ final class Configuration {
   // Set responseFormat to {"type": "json_object"} in your chat completion request for JSON mode.
   final Map<String, dynamic>? responseFormat;
 
-  Configuration({
+  const GroqConfiguration({
     required this.model,
     this.temperature = 0.5,
     this.maxTokens = 1024,

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -26,7 +26,7 @@ final class Configuration {
       case GroqModel.meta:
         return 'llama2-70b-4096';
       case GroqModel.mixtral:
-        return 'mixtal-8x7b-32768';
+        return 'mixtral-8x7b-32768';
       case GroqModel.gemma:
         return 'gemma-7b-it';
     }

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -54,6 +54,11 @@ final class Configuration {
   /// like "[end]".
   final String? stop;
 
+  // Response format can be used to specify the format of the response
+  // JSON mode is a beta feature that guarantees all chat completions are valid JSON.
+  // Set responseFormat to {"type": "json_object"} in your chat completion request for JSON mode.
+  final Map<String, dynamic>? responseFormat;
+
   Configuration({
     required this.model,
     this.temperature = 0.5,
@@ -61,5 +66,6 @@ final class Configuration {
     this.topP = 1.0,
     this.stream = false,
     this.stop,
+    this.responseFormat,
   });
 }

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -1,5 +1,3 @@
-import 'model.dart';
-
 // Groq API Header Keys
 final class ApiHeaderKeys {
   static const String authorization = 'Authorization';
@@ -19,9 +17,7 @@ final class GroqConfiguration {
   /// The model which will generate the completion.
   /// Some models are suitable for natural language
   /// tasks, others specialize in code.
-  final GroqModel model;
-
-  String get modelName => model.name;
+  final String model;
 
   /// Controls randomness: lowering results in less
   /// random completions. As the temperature approaches

--- a/lib/src/groq_chat.dart
+++ b/lib/src/groq_chat.dart
@@ -66,6 +66,7 @@ class GroqChat {
       topP: _configuration.topP,
       stream: _configuration.stream,
       stop: _configuration.stop,
+      responseFormat: _configuration.responseFormat,
     );
   }
 }

--- a/lib/src/groq_chat.dart
+++ b/lib/src/groq_chat.dart
@@ -60,7 +60,7 @@ class GroqChat {
 
     return GroqRequest(
       messages: message,
-      model: _configuration.modelName,
+      model: _configuration.model,
       temperature: _configuration.temperature,
       maxTokens: _configuration.maxTokens,
       topP: _configuration.topP,

--- a/lib/src/groq_chat.dart
+++ b/lib/src/groq_chat.dart
@@ -8,16 +8,16 @@ import 'model.dart';
 /// record the content until the user clean the chat message.
 class GroqChat {
   late ApiClient _apiClient;
-  late Configuration _configuration;
+  late GroqConfiguration _configuration;
   List<GroqMessage> _messages = [];
   GroqMessage? _instructions;
 
   GroqChat({
     required ApiClient apiClient,
-    required GroqModel model,
+    required GroqConfiguration configuration,
   }) {
     _apiClient = apiClient;
-    _configuration = Configuration(model: model);
+    _configuration = configuration;
   }
 
   // Set instruction to the model

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -8,14 +8,12 @@ import 'model.dart';
 //
 final class Groq {
   ApiClient apiClient;
-  GroqModel model;
-  Configuration? configuration;
+  late GroqConfiguration configuration;
   late GroqChat _chat;
 
   Groq._withApiClient({
     required this.apiClient,
-    required this.model,
-    this.configuration,
+    required this.configuration,
   });
 
   //
@@ -23,18 +21,16 @@ final class Groq {
   //
   factory Groq({
     required String apiKey,
-    GroqModel model = GroqModel.meta,
-    Configuration? configuration,
+    GroqConfiguration? configuration,
   }) =>
       Groq._withApiClient(
         apiClient: ApiClient(apiKey: apiKey),
-        model: model,
-        configuration: configuration,
+        configuration: configuration ?? GroqConfiguration(model: GroqModel.meta),
       );
 
   // Start the chat model
   void startChat() {
-    _chat = GroqChat(apiClient: apiClient, model: model);
+    _chat = GroqChat(apiClient: apiClient, configuration: configuration);
   }
 
   // Set intructions to the model of the chat

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -25,7 +25,7 @@ final class Groq {
   }) =>
       Groq._withApiClient(
         apiClient: ApiClient(apiKey: apiKey),
-        configuration: configuration ?? GroqConfiguration(model: GroqModel.meta),
+        configuration: configuration ?? GroqConfiguration(model: 'gemma-7b-it'),
       );
 
   // Start the chat model

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -27,6 +27,7 @@ class GroqRequest {
   double topP;
   bool stream;
   String? stop;
+  Map<String, dynamic>? responseFormat;
 
   GroqRequest({
     required this.messages,
@@ -36,6 +37,7 @@ class GroqRequest {
     required this.topP,
     required this.stream,
     required this.stop,
+    required this.responseFormat,
   });
 
   factory GroqRequest.fromJson(Map<String, dynamic> json) {
@@ -51,6 +53,7 @@ class GroqRequest {
       topP: json['top_p'] as double,
       stream: json['stream'] as bool,
       stop: json['stop'] as String?,
+      responseFormat: json['response_format'] as Map<String, dynamic>?,
     );
   }
 
@@ -63,6 +66,7 @@ class GroqRequest {
       'top_p': topP,
       'stream': stream,
       'stop': stop,
+      'response_format': responseFormat,
     };
   }
 }
@@ -127,8 +131,7 @@ class GroqMessage {
   });
 
   GroqMessage.fromJson(Map<String, dynamic> json)
-      : role = RoleMessage.values.firstWhere(
-            (element) => element.toString().split('.').last == json['role']),
+      : role = RoleMessage.values.firstWhere((element) => element.toString().split('.').last == json['role']),
         content = json['content'] as String;
 
   Map<String, dynamic> toJson() => {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2,9 +2,13 @@
 // Groq Model Option
 //
 enum GroqModel {
-  meta,
-  mixtral,
-  gemma,
+  meta('llama2-70b-4096'),
+  mixtral('mixtral-8x7b-32768'),
+  gemma('gemma-7b-it');
+
+  const GroqModel(this.name);
+
+  final String name;
 }
 
 //

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1,18 +1,19 @@
 //
 // Groq Model Option
+// This should just be a string
+// enum GroqModel {
+//   meta('llama2-70b-4096'),
+//   mixtral('mixtral-8x7b-32768'),
+//   gemma('gemma-7b-it');
+
+//   const GroqModel(this.name);
+
+//   final String name;
+// }
+
+
 //
-enum GroqModel {
-  meta('llama2-70b-4096'),
-  mixtral('mixtral-8x7b-32768'),
-  gemma('gemma-7b-it');
-
-  const GroqModel(this.name);
-
-  final String name;
-}
-
-//
-// Type of massage roles
+// Type of message roles
 //
 enum RoleMessage {
   system,


### PR DESCRIPTION
I switched to model enums then decided to switch to text model name.
model names/id shouldn't be static since they keep adding/removing models, so i have decided to just use configurable string as model name instead of enum.
Response format is for enabling new JSON mode feature.