### PR TITLE
Support for Gemma2 and new Llama 3 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.4
+- Fix typo.
+
 ## 0.0.3
 - Export Groq model.
 - Add Gemma model.

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -23,14 +23,20 @@ final class Configuration {
 
   String get modelName {
     switch (model) {
-      case GroqModel.meta:
-        return 'llama2-70b-4096';
       case GroqModel.mixtral:
         return 'mixtral-8x7b-32768';
       case GroqModel.gemma:
         return 'gemma-7b-it';
       case GroqModel.gemma2:
-        return 'gemma2-9b-it'; 
+        return 'gemma2-9b-it';
+      case GroqModel.llama2:
+        return 'llama2-70b-4096';
+      case GroqModel.llama3_8B:
+        return 'llama3-8b-8192';
+      case GroqModel.llama3_70B:
+        return 'llama3-70b-8192';
+      case GroqModel.llamaGuard3_8B:
+        return 'llama-guard-3-8b';
     }
   }
 

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -26,7 +26,7 @@ final class Configuration {
       case GroqModel.meta:
         return 'llama2-70b-4096';
       case GroqModel.mixtral:
-        return 'mixtal-8x7b-32768';
+        return 'mixtral-8x7b-32768';
       case GroqModel.gemma:
         return 'gemma-7b-it';
     }

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -29,6 +29,8 @@ final class Configuration {
         return 'mixtral-8x7b-32768';
       case GroqModel.gemma:
         return 'gemma-7b-it';
+      case GroqModel.gemma2:
+        return 'gemma2-9b-it'; 
     }
   }
 

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -23,7 +23,7 @@ final class Groq {
   //
   factory Groq({
     required String apiKey,
-    GroqModel model = GroqModel.meta,
+    GroqModel model = GroqModel.llama3_8B,
     Configuration? configuration,
   }) =>
       Groq._withApiClient(

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2,10 +2,13 @@
 // Groq Model Option
 //
 enum GroqModel {
-  meta,
   mixtral,
   gemma,
   gemma2,
+  llama2,
+  llama3_70B,
+  llama3_8B,
+  llamaGuard3_8B,
 }
 
 //

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -5,6 +5,7 @@ enum GroqModel {
   meta,
   mixtral,
   gemma,
+  gemma2,
 }
 
 //

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: groq
-version: 0.0.3
+version: 0.0.4
 description: >-
   The Groq Dart SDK enables developers to use Groq's api.
   Groq is on a mission to set the standard for GenAI inference speed, helping real-time AI applications come to life today.


### PR DESCRIPTION
# GroqModel Update

## Recent Changes

I updated the `GroqModel` enum to include support for new models and improve naming consistency.

### New Supported Models

- Gemma 2
- Llama 3 (various versions)
- Llama Guard 3

### Changes in Nomenclature

I have updated the nomenclature of the models to follow a more consistent pattern:

- Models previously labeled as "Meta" are now identified as "Llama" followed by the version number and model size in parameters.

### Updated Model List

- gemma2-9b-it
- llama2-70b-4096
- llama3-8b-8192
- llama3-70b-8192
- llama-guard-3-8b

### Thanks for your time maintaining this package!
